### PR TITLE
Disallow creating invalidated questions

### DIFF
--- a/contracts/DaoModule.sol
+++ b/contracts/DaoModule.sol
@@ -105,6 +105,7 @@ contract DaoModule {
         bytes32 expectedQuestionId = getQuestionId(
             templateId, question, arbitrator, timeout, 0, nonce
         );
+        require(questionStates[expectedQuestionId] == 0, "New question state is not unset");
         questionStates[expectedQuestionId] = 1;
         bytes32 questionId = oracle.askQuestion(templateId, question, arbitrator, timeout, 0, nonce);
         require(expectedQuestionId == questionId, "Unexpected question id");


### PR DESCRIPTION
This PR enforces that the state of the question created by `addProposalWithNonce` has not been set previously.
In this way, a question can be invalidated without waiting for its creation.

Note that calling this function twice with the same parameters should now fail at the new check. Previously, it would have failed at the `oracle.askQuestion` call. Should I add an extra test for this?

### Test plan
New unit test.